### PR TITLE
Switch to LWJGL with macOS ARM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spinning Top Simulation
 
-This project visualises the motion of a symmetrical spinning top using Java and JOGL. The physics is based on the Hamiltonian formulation for a rigid body under gravity. The orientation of the top is described by the Euler angles `theta`, `phi` and `psi`. A fourth‑order Runge–Kutta method with adaptive step size integrates the equations of motion each frame and the result is rendered as a simple 3‑D cone.
+This project visualises the motion of a symmetrical spinning top using Java and LWJGL. The physics is based on the Hamiltonian formulation for a rigid body under gravity. The orientation of the top is described by the Euler angles `theta`, `phi` and `psi`. A fourth‑order Runge–Kutta method with adaptive step size integrates the equations of motion each frame and the result is rendered as a simple 3‑D cone.
 
 ## Building
 
@@ -10,7 +10,7 @@ The project uses Maven. Compile and package the application with
 mvn package
 ```
 
-This produces `target/spinning-top-1.0-SNAPSHOT.jar`. Maven will download JOGL and its dependencies when building for the first time.
+This produces `target/spinning-top-1.0-SNAPSHOT.jar`. Maven will download LWJGL and its dependencies, including the macOS ARM64 native libraries, when building for the first time.
 
 ## Running
 
@@ -22,7 +22,7 @@ java -jar target/spinning-top-1.0-SNAPSHOT.jar
 
 A window opens showing a spinning cone. The arrow keys are not used; the simulation simply runs with the configured parameters. To experiment with different motions edit the initial conditions in `SpinningTopSimulation` and rebuild.
 
-Make sure the JOGL native libraries are available on your system when running the program.
+LWJGL bundles the required native libraries so no additional setup is needed when running the program.
 
 ## Physics background
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,19 +8,62 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <lwjgl.version>3.3.1</lwjgl.version>
+        <lwjgl.natives>natives-macos-arm64</lwjgl.natives>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.lwjgl</groupId>
+                <artifactId>lwjgl-bom</artifactId>
+                <version>${lwjgl.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
-            <groupId>org.jogamp.jogl</groupId>
-            <artifactId>jogl-all-main</artifactId>
-            <version>2.3.2</version>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jogamp.gluegen</groupId>
-            <artifactId>gluegen-rt-main</artifactId>
-            <version>2.3.2</version>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-glfw</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-opengl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-glu</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl</artifactId>
+            <classifier>${lwjgl.natives}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-glfw</artifactId>
+            <classifier>${lwjgl.natives}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-opengl</artifactId>
+            <classifier>${lwjgl.natives}</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.lwjgl</groupId>
+            <artifactId>lwjgl-glu</artifactId>
+            <classifier>${lwjgl.natives}</classifier>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -29,17 +72,17 @@
                 <version>3.5.1</version>
                 <executions>
                     <execution>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>shade</goal>
-                    </goals>
-                    <configuration>
-                        <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>com.example.SpinningTopViewer</mainClass>
-                        </transformer>
-                        </transformers>
-                    </configuration>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.SpinningTopViewer</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/com/example/SpinningTopViewer.java
+++ b/src/main/java/com/example/SpinningTopViewer.java
@@ -1,75 +1,76 @@
 package com.example;
 
-/** Simple JOGL viewer for the spinning top simulation. */
-import com.jogamp.opengl.*;
-import com.jogamp.opengl.glu.GLU;
-import com.jogamp.opengl.util.gl2.GLUT;
-import com.jogamp.opengl.awt.GLCanvas;
-import com.jogamp.opengl.util.Animator;
-import javax.swing.JFrame;
+/** Simple LWJGL viewer for the spinning top simulation. */
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL11.*;
 
-public class SpinningTopViewer implements GLEventListener {
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.util.glu.Cylinder;
+import org.lwjgl.util.glu.GLU;
+
+public class SpinningTopViewer {
     private SpinningTopSimulation sim = new SpinningTopSimulation();
     private double time = 0;
+    private long window;
+    private final int width = 800;
+    private final int height = 600;
+    private final Cylinder cone = new Cylinder();
+    private final GLU glu = new GLU();
 
-    public static void main(String[] args){
-        GLProfile profile = GLProfile.get(GLProfile.GL2);
-        GLCapabilities caps = new GLCapabilities(profile);
-        GLCanvas canvas = new GLCanvas(caps);
-        SpinningTopViewer app = new SpinningTopViewer();
-        canvas.addGLEventListener(app);
-        Animator animator = new Animator(canvas);
-        JFrame frame = new JFrame("Spinning Top");
-        frame.getContentPane().add(canvas);
-        frame.setSize(800,600);
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.setVisible(true);
-        animator.start();
+    public static void main(String[] args) {
+        new SpinningTopViewer().run();
     }
 
-    @Override
-    public void init(GLAutoDrawable drawable){
-        GL2 gl = drawable.getGL().getGL2();
-        gl.glClearColor(0,0,0,1);
-        gl.glEnable(GL.GL_DEPTH_TEST);
+    public void run() {
+        init();
+        loop();
+        glfwDestroyWindow(window);
+        glfwTerminate();
     }
 
-    @Override
-    public void reshape(GLAutoDrawable drawable,int x,int y,int width,int height){
-        GL2 gl = drawable.getGL().getGL2();
-        gl.glViewport(0,0,width,height);
-        gl.glMatrixMode(GL2.GL_PROJECTION);
-        gl.glLoadIdentity();
-        float aspect = (float)width/(float)height;
-        glu.gluPerspective(45.0f, aspect, 1.0f, 500.0f);
-        gl.glMatrixMode(GL2.GL_MODELVIEW);
+    private void init() {
+        GLFWErrorCallback.createPrint(System.err).set();
+        if (!glfwInit()) {
+            throw new IllegalStateException("Unable to initialize GLFW");
+        }
+        window = glfwCreateWindow(width, height, "Spinning Top", 0, 0);
+        if (window == 0) {
+            throw new RuntimeException("Failed to create window");
+        }
+        glfwMakeContextCurrent(window);
+        glfwSwapInterval(1);
+        GL.createCapabilities();
+
+        glClearColor(0f, 0f, 0f, 1f);
+        glEnable(GL_DEPTH_TEST);
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        glu.gluPerspective(45.0f, (float) width / height, 1.0f, 500.0f);
+        glMatrixMode(GL_MODELVIEW);
     }
 
-    private GLU glu = new GLU();
+    private void loop() {
+        while (!glfwWindowShouldClose(window)) {
+            glfwPollEvents();
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            glLoadIdentity();
+            glu.gluLookAt(0, 0, 100, 0, 0, 0, 0, 1, 0);
 
-    @Override
-    public void display(GLAutoDrawable drawable){
-        GL2 gl = drawable.getGL().getGL2();
-        gl.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT);
-        gl.glLoadIdentity();
-        glu.gluLookAt(0,0,100, 0,0,0, 0,1,0);
+            glRotated(sim.getParameter().phi * 180 / Math.PI, 0, 1, 0);
+            glRotated(sim.getParameter().theta * 180 / Math.PI, 1, 0, 0);
+            glRotated(sim.getParameter().psi * 180 / Math.PI, 0, 0, 1);
+            drawTop();
 
-        gl.glRotated(sim.getParameter().phi*180/Math.PI, 0,1,0);
-        gl.glRotated(sim.getParameter().theta*180/Math.PI, 1,0,0);
-        gl.glRotated(sim.getParameter().psi*180/Math.PI, 0,0,1);
-        drawTop(gl);
+            time += sim.getParameter().dt;
+            sim.NDSolve(time, time + sim.getParameter().dt);
 
-        time += sim.getParameter().dt;
-        sim.NDSolve(time, time + sim.getParameter().dt);
+            glfwSwapBuffers(window);
+        }
     }
 
-    private void drawTop(GL2 gl){
-        gl.glColor3d(0.8,0.2,0.2);
-        glut.glutSolidCone(5,20,20,20);
+    private void drawTop() {
+        glColor3f(0.8f, 0.2f, 0.2f);
+        cone.draw(5f, 0f, 20f, 20, 20);
     }
-
-    private com.jogamp.opengl.util.gl2.GLUT glut = new com.jogamp.opengl.util.gl2.GLUT();
-
-    @Override
-    public void dispose(GLAutoDrawable drawable){ }
 }


### PR DESCRIPTION
## Summary
- replace JOGL viewer with LWJGL implementation
- update Maven configuration for LWJGL and macOS ARM64 natives
- refresh README instructions

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6852cae862f08327a885bcf4bd0780f8